### PR TITLE
Add rom dir support for os.rom, basic.rom, amsdos.rom

### DIFF
--- a/src/cpc/cpc.c
+++ b/src/cpc/cpc.c
@@ -115,26 +115,43 @@ static unsigned long   NopCount = 0;
 /* DOS rom is NULL if no DOS is on the motherboard */
 /* basic rom */
 static const unsigned char *pBasic;
+/* An allocated buffer for the ROM, so they can be overridden */
+static unsigned char *pBasic_ROM;
 
 /* os rom */
 const unsigned char *pOS;
+/* An allocated buffer for the ROM, so they can be overridden */
+static unsigned char *pOS_Rom;
 
 /* dos rom */
 static const unsigned char *pDOS;
+/* An allocated buffer for the ROM, so they can be overridden */
+static unsigned char *pDOS_Rom;
 
 void CPC_SetOSRom(const unsigned char *pOSRom)
 {
-	pOS = pOSRom;
+	free(pOS_Rom);
+	pOS_Rom = malloc(16384);
+	memcpy(pOS_Rom, pOSRom, 16384);
+
+	pOS = pOS_Rom;
 }
 
 void CPC_SetBASICRom(const unsigned char *pBASICROM)
 {
-	pBasic = pBASICROM;
+	free(pBasic_ROM);
+	pBasic_ROM = malloc(16384);
+	memcpy(pBasic_ROM, pBASICROM, 16384);
+
+	pBasic = pBasic_ROM;
 }
 
 void CPC_SetDOSRom(const unsigned char *pDOSRom)
 {
-	pDOS = pDOSRom;
+	free(pDOS_Rom);
+	pDOS_Rom = malloc(16384);
+	memcpy(pDOS_Rom, pDOSRom, 16384);
+	pDOS = pDOS_Rom;
 }
 
 

--- a/src/cpc/cpc1.c
+++ b/src/cpc/cpc1.c
@@ -122,16 +122,19 @@ const unsigned char *pOS;
 /* dos rom */
 static const unsigned char *pDOS;
 
+/* set the OS rom image */
 void CPC_SetOSRom(const unsigned char *pOSRom)
 {
 	pOS = pOSRom;
 }
 
+/* set the BASIC rom image */
 void CPC_SetBASICRom(const unsigned char *pBASICROM)
 {
 	pBasic = pBASICROM;
 }
 
+/* set the DOS rom image */
 void CPC_SetDOSRom(const unsigned char *pDOSRom)
 {
 	pDOS = pDOSRom;

--- a/src/unix/configfile.c
+++ b/src/unix/configfile.c
@@ -235,9 +235,10 @@ void saveConfigFile()
 			fprintf(fh,"tapedir=%s\n",tapeDirectory);
 		if (cartDirectory)
 			fprintf(fh,"cartdir=%s\n",cartDirectory);
-		
+		if (romDirectory)
+			fprintf(fh,"romdir=%s\n",romDirectory);
 
-		/*if (diskPathDriveA)	// FIXME: Disabled because of segv
+		if (diskPathDriveA)	// FIXME: Disabled because of segv
 			fprintf(fh,"drivea=%s\n",diskPathDriveA);
 		if (diskPathDriveB)
 			fprintf(fh,"driveb=%s\n",diskPathDriveB);
@@ -248,7 +249,7 @@ void saveConfigFile()
 		if (multifaceCPCPath)
 			fprintf(fh,"mfcpcrom=%s\n",multifaceCPCPath);
 		if (multifacePLUSPath)
-			fprintf(fh,"mfplusrom=%s\n",multifacePLUSPath);*/
+			fprintf(fh,"mfplusrom=%s\n",multifacePLUSPath);
 		if (snapDirectory)
 			fprintf(fh,"snapdir=%s\n",snapDirectory);
 
@@ -427,7 +428,7 @@ void parseLine(const char *s)
 
 			if (strcmp(sVariable, KEY_ROMDIR)==0)
 			{
-
+				setRomDirectory(sValue);
 			}
 			else 
 			if (strcmp(sVariable, KEY_DISKDIR)==0)
@@ -512,7 +513,6 @@ void parseLine(const char *s)
 	}
 }
 
-
 const char *getRomDirectory() {
 	return romDirectory;
 }
@@ -534,7 +534,7 @@ const char *getSnapDirectory() {
 	return snapDirectory;
 }
 
-void setRomDirectory(const char *sPath) 
+void setRomDirectory(const char *sPath)
 {
 	setPath(&romDirectory, sPath);
 }

--- a/src/unix/global.c
+++ b/src/unix/global.c
@@ -90,6 +90,8 @@ unsigned long *pLength)
 				/* report position */
 				FileSize = ftell(fh);
 
+				/* fprintf(stderr, "Host_LoadFile: size %d\n", FileSize); */
+
 				fseek(fh, 0, SEEK_SET);
 			
 				if (FileSize!=0)

--- a/src/unix/main.c
+++ b/src/unix/main.c
@@ -56,6 +56,7 @@ void init_main();
 
 
 /* 464 base system -> cassette only, 64k only */
+/* This is where the OS, Basic, etc ROMs for the 464 are setup */
 void ConfigCPC464()
 {
 	CPC_SetOSRom(roms_cpc464.os.start);
@@ -81,9 +82,12 @@ void ConfigCPC664()
 /* 6128 base system -> disc, 128k only */
 void ConfigCPC6128()
 {
+	const char *rPath = NULL;
+
 	CPC_SetOSRom(roms_cpc6128.os.start);
 	CPC_SetBASICRom(roms_cpc6128.basic.start);
 	CPC_SetDOSRom(rom_amsdos.start);
+
 	Amstrad_DiscInterface_Install();
 	Amstrad_RamExpansion_Install();
 	CPC_SetHardware(CPC_HW_CPC);

--- a/src/unix/main.c
+++ b/src/unix/main.c
@@ -51,16 +51,69 @@ extern BOOL toggleFullscreenLater;
 #endif
 
 /* Forward declarations */
-void init_main();
+void init_main(int argc, char *argv[]);
 //char *getLocalIfNull(char *s);
 
+static void
+ConfigRomOverrides()
+{
+	const char *rPath = NULL;
+	char filename[512] = { 0, };
+	char *pRomData = NULL;
+	unsigned long RomSize = 0;
+
+	rPath = getRomDirectory();
+	/*
+	 * If we have a ROM directory then check in each
+	 * for the ROMs that we could load.
+	 */
+	if (rPath == NULL) {
+		return;
+	}
+
+	/* OS ROM image */
+	filename[0] = 0x0;
+	snprintf(filename, sizeof(filename) - 1,
+	    "%s/%s", rPath, "os.rom");
+	LoadFile(filename, &pRomData, &RomSize);
+	if (pRomData != NULL) {
+		CPC_SetOSRom(pRomData);	/* XXX size? */
+		free(pRomData);
+	}
+	pRomData = NULL;
+	RomSize = 0;
+
+	/* BASIC */
+	filename[0] = 0x0;
+	snprintf(filename, sizeof(filename) - 1,
+	    "%s/%s", rPath, "basic.rom");
+	LoadFile(filename, &pRomData, &RomSize);
+	if (pRomData != NULL) {
+		CPC_SetBASICRom(pRomData);	/* XXX size? */
+		free(pRomData);
+	}
+	pRomData = NULL;
+	RomSize = 0;
+
+	/* DOS */
+	filename[0] = 0x0;
+	snprintf(filename, sizeof(filename) - 1,
+	    "%s/%s", rPath, "amsdos.rom");
+	LoadFile(filename, &pRomData, &RomSize);
+	if (pRomData != NULL) {
+		CPC_SetDOSRom(pRomData);	/* XXX size? */
+		free(pRomData);
+	}
+	pRomData = NULL;
+	RomSize = 0;
+}
 
 /* 464 base system -> cassette only, 64k only */
-/* This is where the OS, Basic, etc ROMs for the 464 are setup */
 void ConfigCPC464()
 {
 	CPC_SetOSRom(roms_cpc464.os.start);
 	CPC_SetBASICRom(roms_cpc464.basic.start);
+	ConfigRomOverrides();
 	Amstrad_DiscInterface_DeInstall();
 	Amstrad_RamExpansion_DeInstall();
 	CPC_SetHardware(CPC_HW_CPC);
@@ -73,6 +126,7 @@ void ConfigCPC664()
 	CPC_SetOSRom(roms_cpc664.os.start);
 	CPC_SetBASICRom(roms_cpc664.basic.start);
 	CPC_SetDOSRom(rom_amsdos.start);
+	ConfigRomOverrides();
 	Amstrad_DiscInterface_Install();
 	Amstrad_RamExpansion_DeInstall();
 	CPC_SetHardware(CPC_HW_CPC);
@@ -82,12 +136,11 @@ void ConfigCPC664()
 /* 6128 base system -> disc, 128k only */
 void ConfigCPC6128()
 {
-	const char *rPath = NULL;
-
+	/* Setup default ROMs first */
 	CPC_SetOSRom(roms_cpc6128.os.start);
 	CPC_SetBASICRom(roms_cpc6128.basic.start);
 	CPC_SetDOSRom(rom_amsdos.start);
-
+	ConfigRomOverrides();
 	Amstrad_DiscInterface_Install();
 	Amstrad_RamExpansion_Install();
 	CPC_SetHardware(CPC_HW_CPC);
@@ -100,6 +153,7 @@ void ConfigCPC6128s()
 	CPC_SetOSRom(roms_cpc6128s.os.start);
 	CPC_SetBASICRom(roms_cpc6128s.basic.start);
 	CPC_SetDOSRom(rom_amsdos.start);
+	ConfigRomOverrides();
 	Amstrad_DiscInterface_Install();
 	Amstrad_RamExpansion_Install();
 	CPC_SetHardware(CPC_HW_CPC);
@@ -131,6 +185,7 @@ void ConfigKCCompact()
 {
 	CPC_SetOSRom(roms_kcc.os.start);
 	CPC_SetBASICRom(roms_kcc.basic.start);
+	ConfigRomOverrides();
 	Amstrad_DiscInterface_DeInstall();
 	Amstrad_RamExpansion_DeInstall();
 	CPC_SetHardware(CPC_HW_KCCOMPACT);
@@ -210,27 +265,28 @@ int main(int argc, char *argv[])
 
 void sdl_InitialiseJoysticks(void);
 
+/* name, has_arg, flag, val */
+static struct option long_options[] = {
+	{"tape", required_argument, NULL, 't'},
+	{"drivea", required_argument, NULL, 'a'},
+	{"driveb", required_argument, NULL, 'b'},
+	{"cart", required_argument, NULL, 'c'},
+	{"frameskip", required_argument, NULL, 'f'},
+	{"crtctype", required_argument, NULL, 'r'},
+	{"cpctype", required_argument, NULL, 'p'},
+	{"snapshot", required_argument, NULL, 's'},
+	{"kbdtype", required_argument, NULL, 'k'},
+	{"soundplugin", required_argument, NULL, 'o'},
+#ifdef HAVE_SDL
+	{"doublesize", no_argument, NULL, 'd'},
+	{"fullscreen", no_argument, NULL, 'u'},
+#endif
+	{"help", no_argument, NULL, 'h'},
+	{NULL, 0, NULL, 0}
+};
+
 void init_main(int argc, char *argv[]) {
 	int kbd = -1;
-	/* name, has_arg, flag, val */
-	static struct option long_options[] = {
-		{"tape", 1, 0, 't'},
-		{"drivea", 1, 0, 'a'},
-		{"driveb", 1, 0, 'b'},
-		{"cart", 1, 0, 'c'},
-		{"frameskip", 1, 0, 'f'},
-		{"crtctype", 1, 0, 'r'},
-		{"cpctype", 1, 0, 'p'},
-		{"snapshot", 1, 0, 's'},
-		{"kbdtype", 1, 0, 'k'},
-		{"soundplugin", 1, 0, 'o'},
-#ifdef HAVE_SDL
-		{"doublesize", 0, 0, 'd'},
-		{"fullscreen", 0, 0, 'u'},
-#endif
-		{"help", 0, 0, 'h'},
-		{0, 0, 0, 0}
-	};
 	int c;
 	int digit_optind = 0;
 	char *tape = NULL;
@@ -298,6 +354,7 @@ void init_main(int argc, char *argv[]) {
 
 		}
 	}
+
 	printf("tape: %s\n", tape);
 
 	CPCEmulation_InitialiseDefaultSetup();


### PR DESCRIPTION
Add support for the ROM directory, so the base ROMs can be added in.
This allows for modified base ROMs, eg for testing out patched firmware ROMs.

This only applies for the non-plus models. The plus models use cartridges and the setup path is a little different.

Whilst here, flip on the drive config file handling, it works fine now.